### PR TITLE
Gee latitude data fix

### DIFF
--- a/ee_codes/landsat-7-images-used-for-labelling-2000-nepal
+++ b/ee_codes/landsat-7-images-used-for-labelling-2000-nepal
@@ -3,7 +3,7 @@ var dataset = ee.Image('CGIAR/SRTM90_V4');
 var elevation = dataset.select('elevation');
 var slope = ee.Terrain.slope(elevation);
 
-// to match iamge bands
+// to match image bands
 elevation = elevation.float();
 slope = slope.float();
 
@@ -16,8 +16,8 @@ for (var i = 0; i < arrayLength; i++) {
   var image = ee.Image(image_id);
   image = image.float();
   Map.addLayer(image, {bands: ['B4', 'B3', 'B2'], min: 0, max: 255}, 'image'+i);
-  image = ee.Image.cat([image, elevation, slope])
   var geometry = image.geometry();
+  image = ee.Image.cat([image, elevation, slope])
   console.log(image_id);
   Export.image.toDrive({
     image: image,

--- a/ee_codes/landsat-7-images-used-for-labelling-2000-nepal
+++ b/ee_codes/landsat-7-images-used-for-labelling-2000-nepal
@@ -3,37 +3,26 @@ var dataset = ee.Image('CGIAR/SRTM90_V4');
 var elevation = dataset.select('elevation');
 var slope = ee.Terrain.slope(elevation);
 
-var image_ids = ["139041_20001226","140041_20011220","142040_20001215",
-                "143039_20001003","143040_20011209"];
+// to match iamge bands
+elevation = elevation.float();
+slope = slope.float();
+
+var image_ids = ["139041_20001226", "140041_20011220", "142040_20001215",
+                "143039_20001003", "143040_20011209"];
 
 var arrayLength = image_ids.length;
 for (var i = 0; i < arrayLength; i++) {
   var image_id = 'LANDSAT/LE07/C01/T1_RT/LE07_'+image_ids[i];
   var image = ee.Image(image_id);
   image = image.float();
-  var geometry = image.geometry();
   Map.addLayer(image, {bands: ['B4', 'B3', 'B2'], min: 0, max: 255}, 'image'+i);
+  image = ee.Image.cat([image, elevation, slope])
+  var geometry = image.geometry();
   console.log(image_id);
   Export.image.toDrive({
     image: image,
     folder: 'EEImages/imagesUsedForLabelling/Nepal/2000',
     description: 'Nepal_'+image_ids[i],
-    region: geometry,
-    scale: 30
-  });
-  // elevation
-  Export.image.toDrive({
-    image: elevation,
-    folder: 'EEImages/Nepal/Elevation/',
-    description: 'Nepal_' + image_ids[i],
-    region: geometry,
-    scale: 30
-  });
-  // slope
-  Export.image.toDrive({
-    image: slope,
-    folder: 'EEImages/Nepal/Slope/',
-    description: 'Nepal_' + image_ids[i],
     region: geometry,
     scale: 30
   });

--- a/ee_codes/landsat-7-images-used-for-labelling-2000-nepal
+++ b/ee_codes/landsat-7-images-used-for-labelling-2000-nepal
@@ -12,17 +12,17 @@ var image_ids = ["139041_20001226", "140041_20011220", "142040_20001215",
 
 var arrayLength = image_ids.length;
 for (var i = 0; i < arrayLength; i++) {
-  var image_id = 'LANDSAT/LE07/C01/T1_RT/LE07_'+image_ids[i];
+  var image_id = 'LANDSAT/LE07/C01/T1_RT/LE07_' + image_ids[i];
   var image = ee.Image(image_id);
   image = image.float();
-  Map.addLayer(image, {bands: ['B4', 'B3', 'B2'], min: 0, max: 255}, 'image'+i);
+  Map.addLayer(image, {bands: ['B4', 'B3', 'B2'], min: 0, max: 255}, 'image' + i);
   var geometry = image.geometry();
   image = ee.Image.cat([image, elevation, slope])
   console.log(image_id);
   Export.image.toDrive({
     image: image,
     folder: 'EEImages/imagesUsedForLabelling/Nepal/2000',
-    description: 'Nepal_'+image_ids[i],
+    description: 'Nepal_' + image_ids[i],
     region: geometry,
     scale: 30
   });

--- a/ee_codes/landsat-7-images-used-for-labelling-2010-nepal
+++ b/ee_codes/landsat-7-images-used-for-labelling-2010-nepal
@@ -78,11 +78,11 @@ var GapFill = function(src, fill, kernelSize, upscale) {
 }
 var image_ids = ["139041_20111225", "140041_20091108",
                   "141040_20101204", "142040_20101211",
-                  "143040_20101218","143039_20111221",
+                  "143040_20101218", "143039_20111221",
                   "144039_20111212"];
-var fill_ids = ["139041_20001226","140041_20011220",
-                "141040_20011227","142040_20001215",
-                "143040_20011209","143039_20001003",
+var fill_ids = ["139041_20001226", "140041_20011220",
+                "141040_20011227", "142040_20001215",
+                "143040_20011209", "143039_20001003",
                 "144039_20011013",];
 var arrayLength = image_ids.length;
 
@@ -96,8 +96,8 @@ elevation = elevation.float();
 slope = slope.float();
 
 for (var i = 0; i < arrayLength; i++) {
-  var image_id = 'LANDSAT/LE07/C01/T1_RT/LE07_'+image_ids[i];
-  var fill_id = 'LANDSAT/LE07/C01/T1_RT/LE07_'+fill_ids[i];
+  var image_id = 'LANDSAT/LE07/C01/T1_RT/LE07_' + image_ids[i];
+  var fill_id = 'LANDSAT/LE07/C01/T1_RT/LE07_' + fill_ids[i];
   var image = ee.Image(image_id);
   var fill = ee.Image(fill_id);
   var image = GapFill(image, fill, 10, true);
@@ -109,7 +109,7 @@ for (var i = 0; i < arrayLength; i++) {
   Export.image.toDrive({
     image: image,
     folder: 'EEImages/imagesUsedForLabelling/Nepal/2010',
-    description: 'Nepal_'+image_ids[i],
+    description: 'Nepal_' + image_ids[i],
     region: geometry,
     scale: 30
   });

--- a/ee_codes/landsat-7-images-used-for-labelling-2010-nepal
+++ b/ee_codes/landsat-7-images-used-for-labelling-2010-nepal
@@ -85,6 +85,16 @@ var fill_ids = ["139041_20001226","140041_20011220",
                 "143040_20011209","143039_20001003",
                 "144039_20011013",];
 var arrayLength = image_ids.length;
+
+// Elevation data
+var dataset = ee.Image('CGIAR/SRTM90_V4');
+var elevation = dataset.select('elevation');
+var slope = ee.Terrain.slope(elevation);
+
+// to match image bands
+elevation = elevation.float();
+slope = slope.float();
+
 for (var i = 0; i < arrayLength; i++) {
   var image_id = 'LANDSAT/LE07/C01/T1_RT/LE07_'+image_ids[i];
   var fill_id = 'LANDSAT/LE07/C01/T1_RT/LE07_'+fill_ids[i];
@@ -94,6 +104,7 @@ for (var i = 0; i < arrayLength; i++) {
   image = image.float();
   var geometry = image.geometry();
   // Map.addLayer(image, {bands: ['B4', 'B3', 'B2'], min: 0, max: 255}, 'image'+i);
+  image = ee.Image.cat([image, elevation, slope])
   console.log(image_id);
   Export.image.toDrive({
     image: image,

--- a/ee_codes/landsat-7-remaining-images-2000-bhutan
+++ b/ee_codes/landsat-7-remaining-images-2000-bhutan
@@ -3,6 +3,10 @@ var dataset = ee.Image('CGIAR/SRTM90_V4');
 var elevation = dataset.select('elevation');
 var slope = ee.Terrain.slope(elevation);
 
+// to match image bands
+elevation = elevation.float();
+slope = slope.float();
+
 var image_ids = ["139041_20001226","137041_20001228","138041_20000930"];
 
 var arrayLength = image_ids.length;
@@ -12,28 +16,13 @@ for (var i = 0; i < arrayLength; i++) {
   image = image.float();
   var geometry = image.geometry();
   Map.addLayer(image, {bands: ['B4', 'B3', 'B2'], min: 0, max: 255}, 'image'+i);
+  image = ee.Image.cat([image, elevation, slope])
   console.log(image);
   //image
   Export.image.toDrive({
     image: image,
     folder: 'EEImages/Bhutan/2000/remainingImages/',
     description: 'Bhutan_'+image_ids[i],
-    region: geometry,
-    scale: 30
-  });
-  // elevation
-  Export.image.toDrive({
-    image: elevation,
-    folder: 'EEImages/Bhutan/Elevation/',
-    description: 'Bhutan_' + image_ids[i],
-    region: geometry,
-    scale: 30
-  });
-  // slope
-  Export.image.toDrive({
-    image: slope,
-    folder: 'EEImages/Bhutan/Slope/',
-    description: 'Bhutan_' + image_ids[i],
     region: geometry,
     scale: 30
   });

--- a/ee_codes/landsat-7-remaining-images-2000-bhutan
+++ b/ee_codes/landsat-7-remaining-images-2000-bhutan
@@ -7,22 +7,22 @@ var slope = ee.Terrain.slope(elevation);
 elevation = elevation.float();
 slope = slope.float();
 
-var image_ids = ["139041_20001226","137041_20001228","138041_20000930"];
+var image_ids = ["139041_20001226", "137041_20001228", "138041_20000930"];
 
 var arrayLength = image_ids.length;
 for (var i = 0; i < arrayLength; i++) {
-  var image_id = 'LANDSAT/LE07/C01/T1_RT/LE07_'+image_ids[i];
+  var image_id = 'LANDSAT/LE07/C01/T1_RT/LE07_' + image_ids[i];
   var image = ee.Image(image_id);
   image = image.float();
   var geometry = image.geometry();
-  Map.addLayer(image, {bands: ['B4', 'B3', 'B2'], min: 0, max: 255}, 'image'+i);
+  Map.addLayer(image, {bands: ['B4', 'B3', 'B2'], min: 0, max: 255}, 'image' + i);
   image = ee.Image.cat([image, elevation, slope])
   console.log(image);
   //image
   Export.image.toDrive({
     image: image,
     folder: 'EEImages/Bhutan/2000/remainingImages/',
-    description: 'Bhutan_'+image_ids[i],
+    description: 'Bhutan_' + image_ids[i],
     region: geometry,
     scale: 30
   });

--- a/ee_codes/landsat-7-remaining-images-2000-nepal
+++ b/ee_codes/landsat-7-remaining-images-2000-nepal
@@ -3,6 +3,10 @@ var dataset = ee.Image('CGIAR/SRTM90_V4');
 var elevation = dataset.select('elevation');
 var slope = ee.Terrain.slope(elevation);
 
+// to match image bands
+elevation = elevation.float();
+slope = slope.float();
+
 var image_ids = ["141040_20011227","144039_20011013",];
 
 var arrayLength = image_ids.length;
@@ -12,28 +16,13 @@ for (var i = 0; i < arrayLength; i++) {
   image = image.float();
   var geometry = image.geometry();
   Map.addLayer(image, {bands: ['B4', 'B3', 'B2'], min: 0, max: 255}, 'image'+i);
+  image = ee.Image.cat([image, elevation, slope])
   console.log(image);
   // image
   Export.image.toDrive({
     image: image,
     folder: 'EEImages/Nepal/2000/remainingImages/',
     description: 'Nepal_'+image_ids[i],
-    region: geometry,
-    scale: 30
-  });
-  // elevation
-  Export.image.toDrive({
-    image: elevation,
-    folder: 'EEImages/Nepal/Elevation/',
-    description: 'Nepal_' + image_ids[i],
-    region: geometry,
-    scale: 30
-  });
-  // slope
-  Export.image.toDrive({
-    image: slope,
-    folder: 'EEImages/Nepal/Slope/',
-    description: 'Nepal_' + image_ids[i],
     region: geometry,
     scale: 30
   });

--- a/ee_codes/landsat-7-remaining-images-2000-nepal
+++ b/ee_codes/landsat-7-remaining-images-2000-nepal
@@ -7,22 +7,22 @@ var slope = ee.Terrain.slope(elevation);
 elevation = elevation.float();
 slope = slope.float();
 
-var image_ids = ["141040_20011227","144039_20011013",];
+var image_ids = ["141040_20011227", "144039_20011013",];
 
 var arrayLength = image_ids.length;
 for (var i = 0; i < arrayLength; i++) {
-  var image_id = 'LANDSAT/LE07/C01/T1_RT/LE07_'+image_ids[i];
+  var image_id = 'LANDSAT/LE07/C01/T1_RT/LE07_' + image_ids[i];
   var image = ee.Image(image_id);
   image = image.float();
   var geometry = image.geometry();
-  Map.addLayer(image, {bands: ['B4', 'B3', 'B2'], min: 0, max: 255}, 'image'+i);
+  Map.addLayer(image, {bands: ['B4', 'B3', 'B2'], min: 0, max: 255}, 'image' + i);
   image = ee.Image.cat([image, elevation, slope])
   console.log(image);
   // image
   Export.image.toDrive({
     image: image,
     folder: 'EEImages/Nepal/2000/remainingImages/',
-    description: 'Nepal_'+image_ids[i],
+    description: 'Nepal_' + image_ids[i],
     region: geometry,
     scale: 30
   });


### PR DESCRIPTION
Fixing the issue where elevation maps don't sync. with image data.
To fix this, either force both data to be exported with the same projection (crs), or concatenate all the data as one image (the assumption is it implicitly uses one projection)