### PR TITLE
Masking dev

### DIFF
--- a/glacier_mapping/data/mask.py
+++ b/glacier_mapping/data/mask.py
@@ -101,7 +101,7 @@ def generate_mask(img_meta, shps):
     for k, shp in enumerate(shps):
         check_crs(img_meta["crs"], shp.crs)
         result[:, :, k] = channel_mask(img_meta, shp)
-    result[:, :, 0] = np.multiply(result[:, :, 0], result[:, :, 1])
+    
     return result
 
 
@@ -123,7 +123,7 @@ def channel_mask(img_meta, shp):
                 poly_shp += [poly_from_coord(geom, img_meta["transform"])]
 
     im_size = (img_meta["height"], img_meta["width"])
-    
+
     try:
         result = rasterize(shapes=poly_shp, out_shape=im_size)
     except ValueError as e:

--- a/glacier_mapping/data/mask.py
+++ b/glacier_mapping/data/mask.py
@@ -123,6 +123,7 @@ def channel_mask(img_meta, shp):
                 poly_shp += [poly_from_coord(geom, img_meta["transform"])]
 
     im_size = (img_meta["height"], img_meta["width"])
+    
     try:
         result = rasterize(shapes=poly_shp, out_shape=im_size)
     except ValueError as e:

--- a/glacier_mapping/data/mask.py
+++ b/glacier_mapping/data/mask.py
@@ -123,7 +123,14 @@ def channel_mask(img_meta, shp):
                 poly_shp += [poly_from_coord(geom, img_meta["transform"])]
 
     im_size = (img_meta["height"], img_meta["width"])
-    return rasterize(shapes=poly_shp, out_shape=im_size)
+    try:
+        result = rasterize(shapes=poly_shp, out_shape=im_size)
+    except ValueError as e:
+        if str(e) == 'No valid geometry objects found for rasterize':
+            result = np.zeros(im_size)
+        else: raise
+
+    return result
 
 
 def poly_from_coord(polygon, transform):

--- a/glacier_mapping/data/slice.py
+++ b/glacier_mapping/data/slice.py
@@ -73,6 +73,12 @@ def slice_pair(img, mask, **kwargs):
     """
     Slice an image / mask pair
     """
+    # maskout areas with nans
+    nan_mask = np.isnan(img[:, :, 0])
+    nan_mask = np.expand_dims(nan_mask, axis=2)
+    nan_mask = np.repeat(nan_mask, mask.shape[-1], axis=2)
+    mask[nan_mask] = 0
+
     img_slices = slice_tile(img, **kwargs)
     mask_slices = slice_tile(mask, **kwargs)
     return img_slices, mask_slices


### PR DESCRIPTION
The fixes involves:
1- accepting debris .shp files even when there is no debris in some tiffs
2- crop images correctly so there are no empty images corresponding to valid labels
3- remove merging the first two channels of the mask into one (so we have 3 diff channels instead of two)