### PR TITLE
Use existing slices to build geo splits

### DIFF
--- a/glacier_mapping/data/process_slices_funs.py
+++ b/glacier_mapping/data/process_slices_funs.py
@@ -80,7 +80,7 @@ def geographic_split(ids, geojsons, slice_meta, dev_ratio=0.10, crs=3857, **kwar
     return splits
 
 
-def reshuffle(split_ids, output_dir="output/", n_cpu=3):
+def reshuffle(split_ids, output_dir="output/"):
     """ Reshuffle Data for Training, given a dictionary specifying train / dev / test split, copy into train / dev / test folders.
 
     Args:
@@ -93,6 +93,7 @@ def reshuffle(split_ids, output_dir="output/", n_cpu=3):
         path = Path(output_dir, split_type)
         os.makedirs(path, exist_ok=True)
 
+    print(split_ids)
     target_locs = {k: [] for k in split_ids}
     for split_type in split_ids:
         for i in range(len(split_ids[split_type])):

--- a/glacier_mapping/data/process_slices_funs.py
+++ b/glacier_mapping/data/process_slices_funs.py
@@ -61,12 +61,13 @@ def geographic_split(ids, geojsons, slice_meta, dev_ratio=0.10, crs=3857, **kwar
 
     for k, path in geojsons.items():
         split_geo = gpd.read_file(path)
-        split_geo = split_geo.to_crs(crs)
+        split_geo = split_geo.to_crs(crs).buffer(0)
 
         for slice_id in ids:
             # get the row of the pandas with the current slice id
             slice_geo = slice_meta[slice_meta.img_slice == slice_id["img"]]["geometry"]
-            slice_geo = slice_geo.to_crs(crs).reset_index()
+            slice_geo = slice_geo.to_crs(crs).reset_index().buffer(0)
+
             if split_geo.contains(slice_geo)[0]:
                 if k == "train":
                     if random.random() < dev_ratio:

--- a/glacier_mapping/experiment_helpers/geo.py
+++ b/glacier_mapping/experiment_helpers/geo.py
@@ -16,35 +16,17 @@ import argparse
 import subprocess
 
 
-def extract_work_region(tiles_dir):
-    """
-    input: directory containing tiles
-    output: geojson of the cascaded union of bounding boxes for the tiles in
-    the directory
-    """
-    bboxes = []
-    for path in pathlib.Path(tiles_dir).glob("*.tif*"):
-        imgf = rasterio.open(path)
-        bbox = shapely.geometry.box(*imgf.bounds)
-        bboxes.append(bbox)
-    return cascaded_union(bboxes)
-
-
 def random_location(polygon):
     """
     Get a random shapely.Point within a polygon
     """
     points = []
     minx, miny, maxx, maxy = polygon.bounds
-
-    while True:
-        ux, uy = random.uniform(minx, maxx), random.uniform(miny, maxy)
-        pnt = shapely.geometry.Point(ux, uy)
-        if polygon.contains(pnt):
-            return pnt
+    ux, uy = random.uniform(minx, maxx), random.uniform(miny, maxy)
+    return shapely.geometry.Point(ux, uy)
 
 
-def grow_region(work_region, init_coord, train_perc=0.8, grow_rate=1000):
+def grow_region(work_region, init_coord, train_perc=0.8, grow_rate=5000):
     """
     Take a shapely point and buffer it into a circle of fraction train_perc of
     the work region, incrementally growing at rate grow_rate.
@@ -59,30 +41,20 @@ def grow_region(work_region, init_coord, train_perc=0.8, grow_rate=1000):
             return region.intersection(work_region)
 
 
-def geo_split(work_region, train_perc=0.8):
+def geo_split(work_region, proposal_region=None, train_perc=0.8):
     """
     input: - geojson specifying the work area
       - relative size of train / test splits (fraction of working area geojson to assign to train or test)
     output: Two geographically disjoint geojsons, one for train and one for test
     """
+    if not proposal_region:
+        proposal_region = work_region
+
     init_coord = random_location(work_region)
     train_region = grow_region(work_region, init_coord, train_perc)
     test_region = work_region.difference(train_region)
     return (train_region, test_region)
 
-
-def reproject_directory(input_dir, output_dir, dst_epsg=3857):
-    """
-    Warp all Tiffs from one directory to 3857
-    """
-    inputs = pathlib.Path(input_dir).glob("*.tif*")
-    for im_path in inputs:
-        print(f"reprojecting {str(im_path)}")
-        loaded_im = rasterio.open(im_path)
-        output_path = pathlib.Path(output_dir, f"{im_path.stem}-warped.tif")
-        subprocess.call(["gdalwarp", "-s_srs", str(loaded_im.crs), "-t_srs",
-                         f"EPSG:{dst_epsg}", str(im_path),
-                         "-wo", "NUM_THREADS=ALL_CPUS", str(output_path)])
 
 def create_gdf(polygon, crs=3857):
     return gpd.GeoDataFrame(geometry=[polygon], crs=crs)
@@ -90,23 +62,17 @@ def create_gdf(polygon, crs=3857):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="create geographic train and test splits")
-    parser.add_argument("-d", "--input_dir", type=str)
+    parser.add_argument("-s", "--slice_metadata", type=str)
     parser.add_argument("-o", "--output_dir", type=str)
-    parser.add_argument("-r", "--reproject", type=bool, default=False)
     args = parser.parse_args()
 
-    # reproject, if requested
-    tiff_dir = args.output_dir
-    if args.reproject:
-        reproject_directory(args.input_dir, args.output_dir, 3857)
-    else:
-        tiff_dir = args.input_dir
-
-    work_region = extract_work_region(tiff_dir)
-    train, test = geo_split(work_region)
+    slice_meta = gpd.read_file(args.slice_metadata)
+    work_region = cascaded_union(slice_meta["geometry"])
+    work_region = gpd.GeoDataFrame(geometry = [work_region], crs = slice_meta.crs)
+    work_region = work_region.to_crs(3857)
+    train, test = geo_split(work_region["geometry"][0])
 
     # convert to geopandas df, and svae to geojson
-    work_df = create_gdf(work_region)
     train_df = create_gdf(train)
     test_df = create_gdf(test)
     work_df.to_file(pathlib.Path(args.output_dir) / "work_region.geojson", driver="GeoJSON")

--- a/glacier_mapping/experiment_helpers/geo.py
+++ b/glacier_mapping/experiment_helpers/geo.py
@@ -80,9 +80,8 @@ if __name__ == "__main__":
     train, test = geo_split(work_region["geometry"][0])
 
     # convert to geopandas df, and svae to geojson
-    work_df = create_gdf(work_region)
     train_df = create_gdf(train)
     test_df = create_gdf(test)
-    work_df.to_file(pathlib.Path(args.output_dir) / "work_region.geojson", driver="GeoJSON")
+    work_region.to_file(pathlib.Path(args.output_dir) / "work_region.geojson", driver="GeoJSON")
     train_df.to_file(pathlib.Path(args.output_dir) / "train.geojson", driver="GeoJSON")
     test_df.to_file(pathlib.Path(args.output_dir) / "test.geojson", driver="GeoJSON")

--- a/glacier_mapping/experiment_helpers/geo.py
+++ b/glacier_mapping/experiment_helpers/geo.py
@@ -80,6 +80,7 @@ if __name__ == "__main__":
     train, test = geo_split(work_region["geometry"][0])
 
     # convert to geopandas df, and svae to geojson
+    work_df = create_gdf(work_region)
     train_df = create_gdf(train)
     test_df = create_gdf(test)
     work_df.to_file(pathlib.Path(args.output_dir) / "work_region.geojson", driver="GeoJSON")

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ Beaker==1.11.0
 bottle==0.12.18
 cheroot==8.4.2
 fiona==1.8.13
-gdal==2.2.2
+gdal==3.0.4
 gdal2tiles==0.1.7
 geopandas==0.8.1
 joblib==0.16.0

--- a/scripts/geo/setup_data.sh
+++ b/scripts/geo/setup_data.sh
@@ -8,7 +8,7 @@ rm -rf $split_dir
 mkdir -p $split_dir
 
 # create train and test geojsons
-for i in $( seq 2 $n_folds)
+for i in $( seq 1 $n_folds)
 do
     echo $i
     mkdir $split_dir/$i

--- a/scripts/geo/setup_data.sh
+++ b/scripts/geo/setup_data.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-echo $1
 source /home/kris/glacier_mapping/.env
 
 cd $ROOT_DIR
@@ -9,8 +8,6 @@ rm -rf $split_dir
 mkdir -p $split_dir
 
 # create train and test geojsons
-mkdir $split_dir/1/
-
 for i in $( seq 2 $n_folds)
 do
     echo $i

--- a/scripts/geo/setup_data.sh
+++ b/scripts/geo/setup_data.sh
@@ -2,39 +2,25 @@
 echo $1
 source /home/kris/glacier_mapping/.env
 
-if [ $1 == "test" ];
-then
-    export input_dir=$DATA_DIR/expers/geographic/test_input/
-    export n_folds=3
-    export mask_path=conf/geo/mask_small.yaml
-else
-    export input_dir=$DATA_DIR/analysis_images
-    export n_folds=10
-    export mask_path=conf/geo/mask.yaml
-fi
-
 cd $ROOT_DIR
 export split_dir=$DATA_DIR/expers/geographic/splits/
+export slice_meta=$DATA_DIR/processed/slices/slices.geojson
 rm -rf $split_dir
 mkdir -p $split_dir
 
 # create train and test geojsons
 mkdir $split_dir/1/
-python3 -m glacier_mapping.experiment_helpers.geo -d $input_dir -o $split_dir/1/ -r True
 
 for i in $( seq 2 $n_folds)
 do
     echo $i
     mkdir $split_dir/$i
-    python3 -m glacier_mapping.experiment_helpers.geo -d $split_dir/1/ -o $split_dir/$i/
+    python3 -m glacier_mapping.experiment_helpers.geo -s $slice_meta -o $split_dir/$i/
 done
-
-# slice
-python3 -m scripts.make_slices -m $mask_path -o $DATA_DIR/expers/geographic/
 
 # construct different folds
 for i in $( seq 1 $n_folds)
 do
     python3 -m scripts.geo.conf -i $i -t conf/geo/postprocess.yaml -o $split_dir/$i/postprocess.yaml
-    python3 -m scripts.process_slices -o $split_dir/$i -m $DATA_DIR/expers/geographic/slices/slices.geojson -p $split_dir/$i/postprocess.yaml
+    python3 -m scripts.process_slices -o $split_dir/$i -m $DATA_DIR/processed/slices/slices.geojson -p $split_dir/$i/postprocess.yaml
 done;

--- a/scripts/geo/setup_data.sh
+++ b/scripts/geo/setup_data.sh
@@ -4,6 +4,7 @@ source /home/kris/glacier_mapping/.env
 cd $ROOT_DIR
 export split_dir=$DATA_DIR/expers/geographic/splits/
 export slice_meta=$DATA_DIR/processed/slices/slices.geojson
+export n_folds=10
 rm -rf $split_dir
 mkdir -p $split_dir
 

--- a/scripts/process_slices.py
+++ b/scripts/process_slices.py
@@ -40,6 +40,8 @@ if __name__ == '__main__':
     split_fun, split_args = next(iter(pconf.split_method.items()))
     split_fun = getattr(pf, split_fun)
     split_ids = split_fun(keep_ids, slice_meta=slice_meta, **split_args)
+    import pdb
+    pdb.set_trace()
     target_locs = pf.reshuffle(split_ids, output_dir)
 
     # global statistics: get the means and variances in the train split

--- a/scripts/process_slices.py
+++ b/scripts/process_slices.py
@@ -23,7 +23,6 @@ if __name__ == '__main__':
 
     # data directories
     output_dir = pathlib.Path(args.output_dir)
-    slice_dir = output_dir / "slices"
 
     # filter all the slices to the ones that matter
     pconf = Dict(yaml.safe_load(open(args.postprocess_conf, "r")))
@@ -40,8 +39,6 @@ if __name__ == '__main__':
     split_fun, split_args = next(iter(pconf.split_method.items()))
     split_fun = getattr(pf, split_fun)
     split_ids = split_fun(keep_ids, slice_meta=slice_meta, **split_args)
-    import pdb
-    pdb.set_trace()
     target_locs = pf.reshuffle(split_ids, output_dir)
 
     # global statistics: get the means and variances in the train split


### PR DESCRIPTION
This builds slices using the `slices.geojson` file created by processing. This lets us avoid reprojecting and remasking all the tiffs.

This also generalizes the region growing routine so that you can start with multiple seed locations. You can recover the previous behavior by setting `n_init=1` in geo_slit.